### PR TITLE
Temporary default format for viewFinder becomes RGB24

### DIFF
--- a/core/rpicam_app.cpp
+++ b/core/rpicam_app.cpp
@@ -323,7 +323,7 @@ void RPiCamApp::ConfigureViewfinder()
 	}
 
 	// Now we get to override any of the default settings from the options_->
-	configuration_->at(0).pixelFormat = libcamera::formats::YUV420;
+	configuration_->at(0).pixelFormat = libcamera::formats::BGR888;
 	configuration_->at(0).size = size;
 	if (options_->viewfinder_buffer_count > 0)
 		configuration_->at(0).bufferCount = options_->viewfinder_buffer_count;
@@ -1168,8 +1168,8 @@ void RPiCamApp::previewThread()
 				preview_cond_var_.wait(lock);
 		}
 
-		if (item.stream->configuration().pixelFormat != libcamera::formats::YUV420)
-			throw std::runtime_error("Preview windows only support YUV420");
+		// if (item.stream->configuration().pixelFormat != libcamera::formats::YUV420)
+		// 	throw std::runtime_error("Preview windows only support YUV420");
 
 		StreamInfo info = GetStreamInfo(item.stream);
 		FrameBuffer *buffer = item.completed_request->buffers[item.stream];


### PR DESCRIPTION
Now the format for viewFinder is YUV420, and can not overwrite by user.  
It should be specified by the user, but not supported for now.
We would like to set RGB24 for the default because YUV420 might not be friendly for display.
Once we have supported Jpeg from YUV420, we can revert it again